### PR TITLE
Fix missing parameter

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -97,7 +97,7 @@ export default class WebpackConfigGenerator {
 
   getDefines(inRendererDir = true) {
     const defines: { [key: string]: string; } = {
-      ASSET_RELOCATOR_BASE_DIR: this.assetRelocatorBaseDir(),
+      ASSET_RELOCATOR_BASE_DIR: this.assetRelocatorBaseDir(inRendererDir),
     };
     if (
       !this.pluginConfig.renderer.entryPoints


### PR DESCRIPTION
passing inRendererDir to assetRelocatorBaseDir

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
The `assetRelocatorBaseDir` method takes a parameter `inRendererDir` which wasn't being passed down. I've added the missing parameter.

